### PR TITLE
Fix webpack 5 deprecation, where `modules` is now a Set

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,12 +108,10 @@ var moduleReader = {
   },
   gatherModuleInfo: function(moduleStats) {
     var moduleMap = {};
-    moduleStats
-      .filter(this.isFromNodeModules.bind(this))
-      .forEach(function(mod) {
-        var moduleName = this.findPackageName(mod.resource);
-        moduleMap[moduleName] = {};
-      }.bind(this));
+    for (const mod of filterSet(moduleStats, this.isFromNodeModules.bind(this))) {
+      var moduleName = this.findPackageName(mod.resource);
+      moduleMap[moduleName] = {};
+    }
     this.moduleMap = moduleMap;
     this.writeModuleInfo();
   }
@@ -296,5 +294,13 @@ var licensePlugin = function(opts) {
   objectAssign(this, composedPlugin, instance(), opts);
   this.apply = this.apply.bind(this);
 };
+
+function* filterSet(set, predicate) {
+  for (const item of set) {
+    if (predicate(item)) {
+      yield item;
+    }
+  }
+}
 
 module.exports = licensePlugin;


### PR DESCRIPTION
Per the [webpack v5 Changelog](https://github.com/webpack/changelog-v5/blob/master/README.md#arrays-to-sets), 

> ## Arrays to Sets
> 
> - Compilation.modules is now a Set
> - Compilation.chunks is now a Set
> 
> There is a compat-layer which prints deprecation warnings.
> 
> MIGRATION: Use Set methods instead of Array methods.

This change switches away from `Compilation.modules.filter()` to a `for-of` construct with a filtering generator function.