### PR TITLE
Properly handle packages in nested node_modules

### DIFF
--- a/change/templated-license-webpack-plugin-ed1c5110-6705-4423-a9c6-299181caad28.json
+++ b/change/templated-license-webpack-plugin-ed1c5110-6705-4423-a9c6-299181caad28.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Properly handle packages in nested node_modules",
+  "packageName": "templated-license-webpack-plugin",
+  "email": "mikula@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/index.js
+++ b/index.js
@@ -67,11 +67,9 @@ var moduleReader = {
     };
   },
   findPackageName: function(jsFilePath) {
-    var tokens = jsFilePath
-      .replace(path.join(this.buildRoot, MODULE_DIR) + path.sep, '')
-      .split(path.sep);
-
-    return (tokens[0].charAt(0) === '@') ? tokens.slice(0, 2).join('/') : tokens[0];
+    var tokens = jsFilePath.split(path.sep);
+    var idx = tokens.lastIndexOf(MODULE_DIR) + 1;
+    return (tokens[idx].charAt(0) === '@') ? tokens.slice(idx, idx + 2).join('/') : tokens[idx];
   },
   writeModuleInfo: function() {
     this.modules = Object.keys(this.moduleMap)


### PR DESCRIPTION
The existing code doesn't handle nested packages, e.g. `node_modules/foo/node_modules/bar/index.js` would be considered part of `foo` when it should be part of `bar`.  Looks like this was a bug in the original `license-webpack-plugin`, but more recent versions seem to handle this case.