### PR TITLE
Handle missing packages

### DIFF
--- a/change/templated-license-webpack-plugin-bf28ce96-3ec1-4a01-b142-f643ed560881.json
+++ b/change/templated-license-webpack-plugin-bf28ce96-3ec1-4a01-b142-f643ed560881.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Handle missing packages",
+  "packageName": "templated-license-webpack-plugin",
+  "email": "mikula@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/index.js
+++ b/index.js
@@ -23,6 +23,10 @@ var moduleReader = {
   },
   readPackageJson: function(mod) {
     var pathName = path.join(this.buildRoot, MODULE_DIR, mod, 'package.json');
+    if (!fs.existsSync(pathName)) {
+      return {};
+    }
+
     var file = fs.readFileSync(pathName);
     return JSON.parse(file);
   },


### PR DESCRIPTION
This seems to be a corner case (or possibly a bug in Yarn 1.x), but there are cases where a package gets installed in a nested `node_modules` but not in the root `node_modules`.  This is just a defensive fix to make sure the plugin doesn't crash in such a situation.